### PR TITLE
[A0-9]環境毎にI/Oできる

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,14 @@
-AUTH0_DOMAIN = [your Domain]
-AUTH0_CLIENT_ID = [your ClientID]
-AUTH0_CLIENT_SECRET = [your Client Secret]
-AUTH0_ALLOW_DELETE = true
+AUTH0_DOMAIN_DEV = auth0 domain for dev
+AUTH0_CLIENT_ID_DEV = auth0 client id for dev
+AUTH0_CLIENT_SECRET_DEV = auth0 client secret for dev
+AUTH0_ALLOW_DELETE_DEV = true
+
+AUTH0_DOMAIN_STAGE = auth0 domain for stage
+AUTH0_CLIENT_ID_STAGE = auth0 client id for stage
+AUTH0_CLIENT_SECRET_STAGE = auth0 client secret for stage
+AUTH0_ALLOW_DELETE_STAGE = true
+
+AUTH0_DOMAIN_PRODUCTION = auth0 domain for pruduction
+AUTH0_CLIENT_ID_PRODUCTION = auth0 client id for pruduction
+AUTH0_CLIENT_SECRET_PRODUCTION = auth0 client secret pruduction for pruduction
+AUTH0_ALLOW_DELETE_PRODUCTION = true

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
 node_modules/
+tenants/

--- a/config_dev.js
+++ b/config_dev.js
@@ -1,0 +1,8 @@
+require('dotenv').config();
+
+module.exports = {
+  AUTH0_DOMAIN: process.env.AUTH0_DOMAIN_DEV,
+  AUTH0_CLIENT_ID: process.env.AUTH0_CLIENT_ID_DEV,
+  AUTH0_CLIENT_SECRET: process.env.AUTH0_CLIENT_SECRET_DEV,
+  AUTH0_ALLOW_DELETE: process.env.AUTH0_ALLOW_DELETE_DEV
+};

--- a/config_production.js
+++ b/config_production.js
@@ -1,0 +1,8 @@
+require('dotenv').config();
+
+module.exports = {
+  AUTH0_DOMAIN: process.env.AUTH0_DOMAIN_PRODUCTION,
+  AUTH0_CLIENT_ID: process.env.AUTH0_CLIENT_ID_PRODUCTION,
+  AUTH0_CLIENT_SECRET: process.env.AUTH0_CLIENT_SECRET_PRODUCTION,
+  AUTH0_ALLOW_DELETE: process.env.AUTH0_ALLOW_DELETE_PRODUCTION
+};

--- a/config_stage.js
+++ b/config_stage.js
@@ -1,0 +1,8 @@
+require('dotenv').config();
+
+module.exports = {
+  AUTH0_DOMAIN: process.env.AUTH0_DOMAIN_STAGE,
+  AUTH0_CLIENT_ID: process.env.AUTH0_CLIENT_ID_STAGE,
+  AUTH0_CLIENT_SECRET: process.env.AUTH0_CLIENT_SECRET_STAGE,
+  AUTH0_ALLOW_DELETE: process.env.AUTH0_ALLOW_DELETE_STAGE
+};

--- a/export.mjs
+++ b/export.mjs
@@ -1,11 +1,42 @@
 import a0deploy from "auth0-deploy-cli";
 
-import config from "./config.js";
+import config_dev from "./config_dev.js";
+import config_stage from "./config_stage.js";
+import config_production from "./config_production.js";
 
-a0deploy
+
+const devEnv = process.argv[2];
+
+if (devEnv === '--dev') {
+  a0deploy
     .dump({
-      output_folder: "./tenants",
-      config: config,
+      output_folder: "./tenants/dev",
+      config: config_dev,
     })
-    .then(() => console.log("yey export was successful"))
+    .then(() => console.log("yey dev export was successful"))
     .catch((err) => console.log(`Oh no, something went wrong. Error: ${err}`));
+
+} else if (devEnv === '--stage'){
+  a0deploy
+    .dump({
+      output_folder: "./tenants/stage",
+      config: config_stage,
+    })
+    .then(() => console.log("yey stage export was successful"))
+    .catch((err) => console.log(`Oh no, something went wrong. Error: ${err}`));
+
+} else if (devEnv === '--production') {
+  a0deploy
+    .dump({
+      output_folder: "./tenants/production",
+      config: config_production,
+    })
+    .then(() => console.log("yey production export was successful"))
+    .catch((err) => console.log(`Oh no, something went wrong. Error: ${err}`));
+
+} else {
+  var error = ' export-auth0 を使うときは引数を指定してください。【ローカル】npm run export-auth0 -- --dev  【ステージ】npm run export-auth0 -- --stage  【本番】npm run export-auth0 -- --production';
+
+  console.log(error);
+
+}

--- a/import.mjs
+++ b/import.mjs
@@ -1,11 +1,40 @@
 import a0deploy from "auth0-deploy-cli";
 
-import config from "./config.js";
+import config_dev from "./config_dev.js";
+import config_stage from "./config_stage.js";
+import config_production from "./config_production.js";
 
-a0deploy
+const devEnv = process.argv[2];
+
+if (devEnv === '--dev') {
+  a0deploy
     .deploy({
-      input_file: "./tenants",
-      config: config,
+      input_file: "./tenants/dev",
+      config: config_dev,
     })
     .then(() => console.log("yey deploy was successful"))
     .catch((err) => console.log(`Oh no, something went wrong. Error: ${err}`));
+
+} else if (devEnv === '--stage'){
+  a0deploy
+    .deploy({
+      input_file: "./tenants/stage",
+      config: config_stage,
+    })
+    .then(() => console.log("yey deploy was successful"))
+    .catch((err) => console.log(`Oh no, something went wrong. Error: ${err}`));
+
+} else if (devEnv === '--production') {
+  a0deploy
+    .deploy({
+      input_file: "./tenants/production",
+      config: config_production,
+    })
+    .then(() => console.log("yey deploy was successful"))
+    .catch((err) => console.log(`Oh no, something went wrong. Error: ${err}`));
+
+} else {
+  var error = ' import-auth0 を使うときは引数を指定してください。【ローカル】npm run import-auth0 -- --dev  【ステージ】npm run import-auth0 -- --stage  【本番】npm run import-auth0 -- --production';
+
+  console.log(error);
+}


### PR DESCRIPTION
## チケットへのリンク
<!-- チケットの番号を追加(https://.........A0-チケット番号) -->
- [該当チケット](https://team-september.atlassian.net/jira/software/projects/A0/boards/3?selectedIssue=A0-9)

## やったこと
<!-- 箇条書きで書く -->
> - 作業内容
- config.jsをローカル・ステージ・本番環境に分割。それぞれのアカウント情報を.envに入れれば読み込んでくれるようにした
- import.mjsとexport.mjsにコマンドから渡ってきた引数を使って条件を分け、それぞれの環境のテナント情報をexport、importできるようにした

## 動作確認
<!-- チェックボックス付きの箇条書きで書く -->
> - [ ] 確認内容
- [x]npm run export-auth0 -- --dev　でローカル環境のテナント情報をexportできた
- [x]npm run export-auth0 -- --stage　でステージ環境のテナント情報をexportできた
- [x]npm run export-auth0 -- --production　で本番環境のテナント情報をexportできた
- [x]npm run import-auth0 -- --devでローカル環境のテナント情報をimportできた
- [x]npm run import-auth0 -- --stageでステージ環境のテナント情報をimportできた
- [x]npm run import-auth0 -- --productionで本番環境のテナント情報をimportできた

## その他
<!-- 実装上の懸念点や注意点などあれば記載 -->
> - 気になる内容
- 引数が思った挙動にならなかった（npm run export-auth0 --dev　としたかったのに、実際はnpm run export-auth0 -- --devとするしかない）
- export.mjsとimport.mjsがファットなロジックになってしまった。

<!-- マークダウンの書き方チートシート (https://qiita.com/Qiita/items/c686397e4a0f4f11683d) -->
